### PR TITLE
Add post-PHP form verification primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,17 @@ Everything else is plumbing.
 
 ## Core modules
 
-| Module      | Purpose                          |
-| ----------- | -------------------------------- |
-| `map.php`   | URL → path → file (+ args)       |
-| `run.php`   | include + invoke + buffer        |
-| `bug.php`  | handler installation             |
-| `pdo.php`   | query helper (no ORM)            |
-| `http.php`  | header staging + response output |
-| `auth.php`  | session login                    |
-| `csrf.php`  | token management                 |
-| `rfc.php`   | small RFC-shaped validators      |
+| Module      | Purpose                                      |
+| ----------- | -------------------------------------------- |
+| `map.php`   | URL → path → file (+ args)                   |
+| `run.php`   | include + invoke + buffer                    |
+| `bug.php`   | handler installation                         |
+| `pdo.php`   | query helper (no ORM)                        |
+| `http.php`  | header staging + response output             |
+| `auth.php`  | session login                                |
+| `csrf.php`  | single-use session token management          |
+| `form.php`  | signed form verification and keyed limits    |
+| `rfc.php`   | small RFC-shaped validators                  |
 
 ---
 
@@ -146,7 +147,7 @@ loot([__DIR__ . '/routes/api/users.php'], [], INVOKE);
 
 Six concerns that belong to infrastructure, external tools, or standalone libraries — not to a request lifecycle toolkit:
 
-1. **Infrastructure** — compression, TLS, rate limiting, static file serving, process management, log rotation. Your web server and OS handle this.
+1. **Infrastructure** — compression, TLS, coarse IP/global rate limiting, static file serving, process management, log rotation. Your web server and OS handle this.
 2. **Data abstraction** — ORM, cache wrappers, storage engine facades. Use PDO, APCu, phpredis directly.
 3. **External I/O** — HTTP client, mail, queues, sockets. Use cURL, PHPMailer, AMQP directly.
 4. **Rendering** — template engines, Markdown, PDF, image processing. Use PHP itself, league/commonmark, dompdf, GD directly.

--- a/doc/form.md
+++ b/doc/form.md
@@ -1,0 +1,295 @@
+# bad\form
+
+Post-PHP form verification primitives.
+
+> CSRF, honeypot, signed submission age, request shape and application-level rate limits. Network and PHP admission controls remain deployment configuration.
+
+---
+
+## Boundary
+
+`bad\form` starts after PHP has accepted the request. Anything enforceable before PHP receives or processes a request belongs in the web server, reverse proxy, WAF, operating system or PHP configuration rather than this API.
+
+Keep these outside the module:
+
+- request-body, upload, input-variable and timeout limits
+- HTTPS and supported-method enforcement
+- trusted-proxy and canonical client-IP configuration
+- coarse IP, connection and global endpoint flood limits
+- secure session-cookie defaults
+- production error suppression, logging bounds and rotation
+
+The application still owns semantic validation, field-length policy, recipient selection, mail-header safety, output escaping and Post/Redirect/Get.
+
+Three controls intentionally overlap:
+
+| Control | Deployment boundary | `bad\form` or application boundary |
+| --- | --- | --- |
+| Request size | Reject oversized bodies before PHP | Enforce field-specific limits |
+| Rate limiting | Stop coarse IP and global floods | Apply session-, form- and identity-specific limits |
+| File uploads | Impose global upload limits | Reject unexpected `$_FILES` for the form |
+
+---
+
+## Requirements
+
+An active PHP session and one stable site secret of at least 32 bytes.
+
+```php
+session_start();
+
+$secret = $_ENV['BADHAT_FORM_SECRET'] ?? '';
+strlen($secret) >= 32 || throw new RuntimeException('BADHAT_FORM_SECRET missing');
+```
+
+Generate a secret once, store it in deployment configuration and keep it stable across requests:
+
+```bash
+php -r 'echo bin2hex(random_bytes(32)), PHP_EOL;'
+```
+
+Changing the secret invalidates outstanding form tokens. Purpose strings, expected field names, honeypot names and rate-limit keys are application-owned and limited to 255 bytes.
+
+---
+
+## Contact-form example
+
+### Render
+
+```php
+use function bad\form\token;
+
+$purpose = 'contact';
+$form_token = token($purpose, $secret, 900); // expires after 15 minutes
+```
+
+```html
+<form method="post" action="/contact">
+    <input
+        type="hidden"
+        name="_form"
+        value="<?= htmlspecialchars($form_token, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"
+    >
+
+    <div class="form-trap" aria-hidden="true">
+        <label>Company <input name="company" tabindex="-1" autocomplete="off"></label>
+    </div>
+
+    <label>Name <input name="name" required maxlength="120"></label>
+    <label>Email <input name="email" type="email" required maxlength="254"></label>
+    <label>Message <textarea name="message" required maxlength="5000"></textarea></label>
+    <button type="submit">Send</button>
+</form>
+```
+
+Visually remove the honeypot from normal interaction with site CSS, but do not declare it as `type="hidden"`; basic bots often skip hidden inputs. Server-side verification remains authoritative.
+
+### Verify
+
+Every primitive returns the same three-slot result. `verify()` executes checks in order, passes the previous successful result to the next callable and stops at the first failure.
+
+```php
+use function bad\form\{
+    result, verify, csrf, timing, honeypot, shape, session_rate
+};
+use const bad\form\{VALID, CODE, REJECT_UNKNOWN};
+
+$purpose = 'contact';
+
+$verification = verify(
+    fn() => csrf($_POST['_form'] ?? null, $purpose, $secret),
+    fn(array $csrf) => timing($csrf, 3),
+    fn() => honeypot($_POST, 'company'),
+    fn() => shape(
+        $_POST,
+        ['_form', 'company', 'name', 'email', 'message'],
+        [],
+        REJECT_UNKNOWN
+    ),
+    fn() => $_FILES === []
+        ? result(true)
+        : result(false, 'shape:files'),
+    fn() => session_rate('contact:minute', 5, 60),
+    fn() => session_rate('contact:hour', 20, 3600)
+);
+
+if (!$verification[VALID]) {
+    error_log('contact form rejected: ' . $verification[CODE]);
+    http_response_code(400);
+    exit('Unable to submit the form.');
+}
+```
+
+Do not expose detailed result codes as public error messages. They are intended for bounded internal diagnostics and application control flow.
+
+After shape verification, apply normal application validation:
+
+```php
+$name = trim($_POST['name']);
+$email = trim($_POST['email']);
+$message = trim($_POST['message']);
+
+if ($name === '' || strlen($name) > 120) {
+    // generic public failure
+}
+
+if (filter_var($email, FILTER_VALIDATE_EMAIL) === false || strlen($email) > 254) {
+    // generic public failure
+}
+
+if ($message === '' || strlen($message) > 5000) {
+    // generic public failure
+}
+```
+
+Field limits are application policy; `shape()` intentionally does not invent them.
+
+---
+
+## CSRF tokens
+
+```php
+token(string $purpose, string $secret, int $ttl = 900, ?int $now = null): string
+csrf($token, string $purpose, string $secret, ?int $now = null): array
+```
+
+A token is bound to:
+
+- the active PHP session
+- the exact form purpose
+- the stable site secret
+- an issue time and expiration time
+
+`csrf()` authenticates the issue time before `timing()` uses it. A token issued for `contact` cannot validate for `signup`.
+
+Tokens are deliberately reusable until expiry. Rotating the PHP session ID invalidates outstanding tokens because the session ID is included only inside the HMAC input and never exposed in the token. This module does not implement token consumption or single-use semantics. The older `bad\csrf\csrf()` API remains separate and retains its existing session-stored, single-use-on-success behavior.
+
+Expected failures return codes such as `csrf:missing`, `csrf:malformed`, `csrf:invalid`, `csrf:future` and `csrf:expired`. Configuration errors throw.
+
+---
+
+## Minimum submission time
+
+```php
+timing(array $csrf, int $minimum): array
+```
+
+`timing()` reads the authenticated age from a successful `csrf()` result. It returns `timing:too_fast` when the form was submitted before the minimum number of seconds elapsed.
+
+This is a low-cost bot signal, not proof that a submission is human.
+
+---
+
+## Honeypot
+
+```php
+honeypot(array $input, string $field): array
+```
+
+The field must exist and be exactly the empty string. Missing, nested-array and populated values return distinct internal codes.
+
+Use a site-owned field name and include it in the expected request shape.
+
+---
+
+## Request shape
+
+```php
+shape(
+    array $input,
+    array $required,
+    array $optional = [],
+    int $behave = 0
+): array
+```
+
+`shape()` enforces:
+
+- every required field name is present
+- every submitted value is a string, not a nested array
+- every submitted field name and value is valid UTF-8
+- submitted values contain no null byte
+- unknown fields are rejected when `REJECT_UNKNOWN` is set
+
+Without `REJECT_UNKNOWN`, extra fields are allowed but still receive scalar, UTF-8 and null-byte checks.
+
+Empty strings are valid shape. Required-value, type, range and length rules remain application validation.
+
+---
+
+## Application-level rate limits
+
+### Session wrapper
+
+```php
+session_rate(string $key, int $limit, int $window, ?int $now = null): array
+```
+
+The key is application-owned. Different keys create independent fixed windows, so limits compose directly:
+
+```php
+$minute = session_rate('contact:minute', 5, 60);
+$hour = session_rate('contact:hour', 20, 3600);
+```
+
+A blocked result uses `rate:limited` and includes bounded `limit`, `reset_at` and `retry_after` metadata.
+
+Verify CSRF before charging a session limit. Otherwise, a cross-site request could consume a victim session's allowance without possessing a valid token.
+
+### Storage-neutral primitive
+
+```php
+rate(
+    array &$buckets,
+    string $key,
+    int $limit,
+    int $window,
+    ?int $now = null
+): array
+```
+
+`rate()` mutates a caller-owned bucket array. This lets an application use the same primitive with session state or with state loaded from another store.
+
+For cross-process or cross-session limits, the application must persist the array and perform the read-modify-write atomically. `rate()` does not disguise database, cache or locking policy.
+
+Coarse IP and global flood protection should still reject traffic at the reverse proxy, web server or WAF before PHP runs.
+
+---
+
+## Structured results
+
+```php
+use const bad\form\{VALID, CODE, DATA};
+```
+
+Each verification result has this shape:
+
+```php
+[
+    VALID => true|false,
+    CODE  => 'stable:internal_code',
+    DATA  => [],
+]
+```
+
+`CODE` must be non-empty valid UTF-8 and is limited to 128 bytes. `DATA` contains bounded metadata only. The built-in primitives do not copy submitted field values or unknown field names into results.
+
+Applications can compose their own checks with the same structure:
+
+```php
+use function bad\form\result;
+
+$length = strlen($_POST['message']) <= 5000
+    ? result(true)
+    : result(false, 'field:length', ['field' => 'message']);
+```
+
+---
+
+## Tests
+
+```bash
+php test/form.php
+```
+
+The test script covers token binding, expiry and reuse; authenticated timing; honeypot behavior; scalar/UTF-8/null-byte shape checks; short-circuit composition; and generic/session rate limits.

--- a/form.php
+++ b/form.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace bad\form;
+
+const VALID = 0;                                                      // structured result: bool
+const CODE  = 1;                                                      // structured result: stable internal code
+const DATA  = 2;                                                      // structured result: bounded metadata, never submitted values
+
+const REJECT_UNKNOWN = 1;                                             // shape(): reject fields outside required + optional
+
+const TTL_MAX           = (1 << 28) - 1;
+const TOKEN_VERSION     = '1';
+const TOKEN_NONCE_BYTES = 16;
+const TOKEN_MAX_BYTES   = 256;
+const SECRET_MIN_BYTES  = 32;
+const NAME_MAX_BYTES    = 255;
+const CODE_MAX_BYTES    = 128;
+const CLOCK_SKEW        = 5;
+
+function result(bool $valid, string $code = 'ok', array $data = []): array
+{
+    ($code !== '' && \strlen($code) <= CODE_MAX_BYTES && text_valid($code))
+                                                                        || throw new \InvalidArgumentException('form:result:code invalid');
+    return [VALID => $valid, CODE => $code, DATA => $data];
+}
+
+function verify(callable ...$checks): array
+{// execute checks in order; each receives the previous successful result and failures short-circuit
+    $current = result(true);
+
+    foreach ($checks as $check) {
+        $next = $check($current);
+        \is_array($next)                                              || throw new \UnexpectedValueException('form:verify:check did not return array');
+        result_guard($next);
+        $current = $next;
+        if (!$current[VALID])
+            break;
+    }
+
+    return $current;
+}
+
+function token(string $purpose, string $secret, int $ttl = 900, ?int $now = null): string
+{// issue a reusable-until-expiry CSRF token bound to purpose, secret and the active session
+    purpose_guard($purpose);
+    secret_guard($secret);
+    $session = session_binding();
+    ($ttl > 0 && $ttl <= TTL_MAX)                                     || throw new \InvalidArgumentException('form:token:ttl out of range');
+
+    $now ??= \time();
+    $now >= 0                                                         || throw new \InvalidArgumentException('form:token:time negative');
+    $now <= \PHP_INT_MAX - $ttl                                      || throw new \InvalidArgumentException('form:token:time overflow');
+
+    $expires = $now + $ttl;
+    $nonce = \bin2hex(\random_bytes(TOKEN_NONCE_BYTES));
+    $payload = TOKEN_VERSION . '.' . $now . '.' . $expires . '.' . $nonce;
+    $mac = \hash_hmac('sha256', signing_input($payload, $purpose, $session), $secret);
+
+    return $payload . '.' . $mac;
+}
+
+function csrf($token, string $purpose, string $secret, ?int $now = null): array
+{// verify signature, session binding, purpose binding and expiration without consuming the token
+    purpose_guard($purpose);
+    secret_guard($secret);
+    $session = session_binding();
+
+    if ($token === null || $token === '')                             return result(false, 'csrf:missing');
+    if (!\is_string($token) || \strlen($token) > TOKEN_MAX_BYTES)    return result(false, 'csrf:malformed');
+
+    $parts = \explode('.', $token);
+    if (\count($parts) !== 5)                                        return result(false, 'csrf:malformed');
+
+    [$version, $issued_raw, $expires_raw, $nonce, $mac] = $parts;
+    if ($version !== TOKEN_VERSION)                                  return result(false, 'csrf:malformed');
+
+    $issued = decimal($issued_raw);
+    $expires = decimal($expires_raw);
+    if ($issued === null || $expires === null || $expires <= $issued
+     || $expires - $issued > TTL_MAX)                                  return result(false, 'csrf:malformed');
+    if (\strlen($nonce) !== TOKEN_NONCE_BYTES * 2
+     || \strspn($nonce, '0123456789abcdef') !== TOKEN_NONCE_BYTES * 2)return result(false, 'csrf:malformed');
+    if (\strlen($mac) !== 64 || \strspn($mac, '0123456789abcdef') !== 64)
+                                                                        return result(false, 'csrf:malformed');
+
+    $payload = $version . '.' . $issued_raw . '.' . $expires_raw . '.' . $nonce;
+    $expected = \hash_hmac('sha256', signing_input($payload, $purpose, $session), $secret);
+    if (!\hash_equals($expected, $mac))                               return result(false, 'csrf:invalid');
+
+    $now ??= \time();
+    $now >= 0                                                         || throw new \InvalidArgumentException('form:csrf:time negative');
+    if ($issued > $now && $issued - $now > CLOCK_SKEW)                return result(false, 'csrf:future');
+    if ($now >= $expires)                                             return result(false, 'csrf:expired');
+
+    return result(true, 'ok', [
+        'issued_at'  => $issued,
+        'expires_at' => $expires,
+        'age'        => \max(0, $now - $issued),
+    ]);
+}
+
+function timing(array $csrf, int $minimum): array
+{// enforce a minimum elapsed time using the signed issue time returned by csrf()
+    $minimum >= 0                                                     || throw new \InvalidArgumentException('form:timing:minimum negative');
+    result_guard($csrf);
+    if (!$csrf[VALID])
+        return $csrf;
+
+    $age = $csrf[DATA]['age'] ?? null;
+    \is_int($age) && $age >= 0                                       || throw new \UnexpectedValueException('form:timing:csrf age missing');
+
+    if ($age < $minimum)
+        return result(false, 'timing:too_fast', ['minimum' => $minimum, 'age' => $age]);
+
+    $data = $csrf[DATA];
+    $data['minimum'] = $minimum;
+    return result(true, 'ok', $data);
+}
+
+function honeypot(array $input, string $field): array
+{// require the trap field to exist, remain scalar and remain exactly empty
+    name_guard($field, 'honeypot');
+
+    if (!\array_key_exists($field, $input))                           return result(false, 'honeypot:missing', ['field' => $field]);
+    if (!\is_string($input[$field]))                                 return result(false, 'honeypot:non_scalar', ['field' => $field]);
+    if ($input[$field] !== '')                                       return result(false, 'honeypot:filled', ['field' => $field]);
+
+    return result(true);
+}
+
+function shape(array $input, array $required, array $optional = [], int $behave = 0): array
+{// enforce expected names and string/UTF-8/null-byte shape; length and semantic checks stay with the application
+    $required = name_set($required, 'required');
+    $optional = name_set($optional, 'optional');
+
+    foreach ($optional as $field => $_)
+        !isset($required[$field])                                    || throw new \InvalidArgumentException("form:shape:duplicate field:$field");
+
+    $allowed = $required + $optional;
+
+    foreach ($input as $field => $value) {
+        $field = (string)$field;
+        $known = isset($allowed[$field]);
+        if ((REJECT_UNKNOWN & $behave) && !$known)                   return result(false, 'shape:unknown');
+        if (\strlen($field) > NAME_MAX_BYTES || !text_valid($field)) return result(false, 'shape:field_name');
+
+        $data = $known ? ['field' => $field] : [];
+        if (!\is_string($value))                                     return result(false, 'shape:non_scalar', $data);
+        if (\strpos($value, "\0") !== false)                        return result(false, 'shape:null_byte', $data);
+        if (\preg_match('//u', $value) !== 1)                        return result(false, 'shape:utf8', $data);
+    }
+
+    foreach ($required as $field => $_)
+        if (!\array_key_exists($field, $input))                       return result(false, 'shape:missing', ['field' => $field]);
+
+    return result(true, 'ok', ['fields' => \count($input)]);
+}
+
+function rate(array &$buckets, string $key, int $limit, int $window, ?int $now = null): array
+{// fixed-window primitive; caller owns persistence and atomicity of the bucket array
+    name_guard($key, 'rate key');
+    $limit > 0                                                        || throw new \InvalidArgumentException('form:rate:limit not positive');
+    $window > 0                                                       || throw new \InvalidArgumentException('form:rate:window not positive');
+
+    $now ??= \time();
+    $now >= 0                                                         || throw new \InvalidArgumentException('form:rate:time negative');
+    $now <= \PHP_INT_MAX - $window                                   || throw new \InvalidArgumentException('form:rate:time overflow');
+
+    $bucket = $buckets[$key] ?? null;
+    if ($bucket !== null) {
+        \is_array($bucket)
+        && \is_int($bucket['count'] ?? null)
+        && \is_int($bucket['reset_at'] ?? null)
+        && \is_int($bucket['window'] ?? null)
+        && $bucket['count'] >= 0
+        && $bucket['reset_at'] >= 0
+        && $bucket['window'] > 0                                     || throw new \UnexpectedValueException("form:rate:bucket invalid:$key");
+    }
+
+    if ($bucket === null || $bucket['reset_at'] <= $now || $bucket['window'] !== $window)
+        $bucket = ['count' => 0, 'reset_at' => $now + $window, 'window' => $window];
+
+    if ($bucket['count'] <= $limit)
+        ++$bucket['count'];                                           // cap naturally at limit + 1 while blocked
+
+    $buckets[$key] = $bucket;
+
+    if ($bucket['count'] > $limit)
+        return result(false, 'rate:limited', [
+            'limit'       => $limit,
+            'reset_at'    => $bucket['reset_at'],
+            'retry_after' => \max(1, $bucket['reset_at'] - $now),
+        ]);
+
+    return result(true, 'ok', [
+        'limit'     => $limit,
+        'remaining' => $limit - $bucket['count'],
+        'reset_at'  => $bucket['reset_at'],
+    ]);
+}
+
+function session_rate(string $key, int $limit, int $window, ?int $now = null): array
+{// session-scoped wrapper around rate(); different keys compose independent form/application limits
+    \session_status() === \PHP_SESSION_ACTIVE                        || throw new \LogicException('form:session_rate:session not active');
+
+    $_SESSION[__NAMESPACE__] ??= [];
+    \is_array($_SESSION[__NAMESPACE__])                              || throw new \UnexpectedValueException('form:session scope invalid');
+    $_SESSION[__NAMESPACE__]['rate'] ??= [];
+    \is_array($_SESSION[__NAMESPACE__]['rate'])                      || throw new \UnexpectedValueException('form:session rate scope invalid');
+
+    $buckets = &$_SESSION[__NAMESPACE__]['rate'];
+    return rate($buckets, $key, $limit, $window, $now);
+}
+
+function result_guard(array $result): void
+{
+    \array_key_exists(VALID, $result)
+    && \array_key_exists(CODE, $result)
+    && \array_key_exists(DATA, $result)
+    && \is_bool($result[VALID])
+    && \is_string($result[CODE])
+    && $result[CODE] !== ''
+    && \strlen($result[CODE]) <= CODE_MAX_BYTES
+    && text_valid($result[CODE])
+    && \is_array($result[DATA])                                      || throw new \UnexpectedValueException('form:result malformed');
+}
+
+function purpose_guard(string $purpose): void
+{
+    name_guard($purpose, 'purpose');
+}
+
+function secret_guard(string $secret): void
+{
+    \strlen($secret) >= SECRET_MIN_BYTES                             || throw new \InvalidArgumentException('form:secret shorter than 32 bytes');
+}
+
+function name_guard(string $name, string $what): void
+{
+    $name !== ''                                                      || throw new \InvalidArgumentException("form:$what empty");
+    \strlen($name) <= NAME_MAX_BYTES                                || throw new \InvalidArgumentException("form:$what too long");
+    text_valid($name)                                                 || throw new \InvalidArgumentException("form:$what invalid text");
+}
+
+function name_set(array $names, string $what): array
+{
+    $set = [];
+    foreach ($names as $name) {
+        \is_string($name)                                            || throw new \InvalidArgumentException("form:shape:$what field not string");
+        name_guard($name, "shape:$what field");
+        !isset($set[$name])                                          || throw new \InvalidArgumentException("form:shape:duplicate field:$name");
+        $set[$name] = true;
+    }
+    return $set;
+}
+
+function text_valid(string $value): bool
+{
+    return \strpos($value, "\0") === false && \preg_match('//u', $value) === 1;
+}
+
+function decimal(string $value): ?int
+{
+    if ($value === '' || !\ctype_digit($value))
+        return null;
+
+    $normalized = \ltrim($value, '0');
+    $normalized = $normalized === '' ? '0' : $normalized;
+    $max = (string)\PHP_INT_MAX;
+    if (\strlen($normalized) > \strlen($max)
+     || (\strlen($normalized) === \strlen($max) && \strcmp($normalized, $max) > 0))
+        return null;
+
+    return (int)$normalized;
+}
+
+function signing_input(string $payload, string $purpose, string $session): string
+{
+    return \strlen($purpose) . ':' . $purpose . "\0"
+         . \strlen($session) . ':' . $session . "\0"
+         . $payload;
+}
+
+function session_binding(): string
+{
+    \session_status() === \PHP_SESSION_ACTIVE                        || throw new \LogicException('form:session not active');
+
+    $session = \session_id();
+    $session !== ''                                                   || throw new \LogicException('form:session id empty');
+    return $session;
+}

--- a/form.php
+++ b/form.php
@@ -180,17 +180,17 @@ function rate(array &$buckets, string $key, int $limit, int $window, ?int $now =
     if ($bucket === null || $bucket['reset_at'] <= $now || $bucket['window'] !== $window)
         $bucket = ['count' => 0, 'reset_at' => $now + $window, 'window' => $window];
 
-    if ($bucket['count'] <= $limit)
-        ++$bucket['count'];                                           // cap naturally at limit + 1 while blocked
-
-    $buckets[$key] = $bucket;
-
-    if ($bucket['count'] > $limit)
+    if ($bucket['count'] >= $limit) {
+        $buckets[$key] = $bucket;                                     // blocked attempts do not grow stored state
         return result(false, 'rate:limited', [
             'limit'       => $limit,
             'reset_at'    => $bucket['reset_at'],
             'retry_after' => \max(1, $bucket['reset_at'] - $now),
         ]);
+    }
+
+    ++$bucket['count'];
+    $buckets[$key] = $bucket;
 
     return result(true, 'ok', [
         'limit'     => $limit,

--- a/test/form.php
+++ b/test/form.php
@@ -1,0 +1,236 @@
+<?php
+
+require \dirname(__DIR__) . '/form.php';
+
+use const bad\form\{VALID, CODE, DATA, REJECT_UNKNOWN, TTL_MAX};
+use function bad\form\{result, verify, token, csrf, timing, honeypot, shape, rate, session_rate};
+
+\session_id('badhat-form-' . \bin2hex(\random_bytes(6)));
+\session_start();
+
+$secret = \str_repeat('a', 32);
+$other_secret = \str_repeat('b', 32);
+$tests = [];
+
+function test(string $name, callable $run): void
+{
+    global $tests;
+    $tests[] = [$name, $run];
+}
+
+function form_session_reset(): void
+{
+    unset($_SESSION['bad\\form']);
+}
+
+function expect(bool $condition, string $message = 'expectation failed'): void
+{
+    if (!$condition)
+        throw new \RuntimeException($message);
+}
+
+function same($expected, $actual, string $message = ''): void
+{
+    if ($expected !== $actual) {
+        $detail = $message === '' ? '' : $message . ': ';
+        throw new \RuntimeException($detail . 'expected ' . \var_export($expected, true) . ', got ' . \var_export($actual, true));
+    }
+}
+
+function code_is(array $result, string $code): void
+{
+    same($code, $result[CODE] ?? null, 'result code');
+}
+
+function throws(string $class, callable $run): void
+{
+    try {
+        $run();
+    } catch (\Throwable $fault) {
+        expect($fault instanceof $class, 'expected ' . $class . ', got ' . $fault::class);
+        return;
+    }
+    throw new \RuntimeException('expected exception ' . $class);
+}
+
+test('token verifies with signed timing metadata', function () use ($secret): void {
+    form_session_reset();
+    $value = token('contact', $secret, 60, 1000);
+    expect((bool)\preg_match('/^1\\.1000\\.1060\\.[0-9a-f]{32}\\.[0-9a-f]{64}$/D', $value), 'token format');
+
+    $checked = csrf($value, 'contact', $secret, 1010);
+    same(true, $checked[VALID]);
+    code_is($checked, 'ok');
+    same(1000, $checked[DATA]['issued_at']);
+    same(1060, $checked[DATA]['expires_at']);
+    same(10, $checked[DATA]['age']);
+});
+
+test('token is purpose, secret and session bound', function () use ($secret, $other_secret): void {
+    form_session_reset();
+    $value = token('contact', $secret, 60, 1000);
+
+    code_is(csrf($value, 'signup', $secret, 1001), 'csrf:invalid');
+    code_is(csrf($value, 'contact', $other_secret, 1001), 'csrf:invalid');
+
+    \session_regenerate_id(true) || throw new \RuntimeException('session regeneration failed');
+    code_is(csrf($value, 'contact', $secret, 1001), 'csrf:invalid');
+});
+
+test('token remains reusable until expiration', function () use ($secret): void {
+    form_session_reset();
+    $value = token('contact', $secret, 10, 1000);
+    same(true, csrf($value, 'contact', $secret, 1001)[VALID]);
+    same(true, csrf($value, 'contact', $secret, 1002)[VALID]);
+    code_is(csrf($value, 'contact', $secret, 1010), 'csrf:expired');
+});
+
+test('token rejects future, missing and malformed input', function () use ($secret): void {
+    form_session_reset();
+    $value = token('contact', $secret, 60, 1000);
+
+    code_is(csrf($value, 'contact', $secret, 990), 'csrf:future');
+    same(0, csrf($value, 'contact', $secret, 997)[DATA]['age']);
+    code_is(csrf(null, 'contact', $secret, 1000), 'csrf:missing');
+    code_is(csrf([], 'contact', $secret, 1000), 'csrf:malformed');
+    code_is(csrf('1.2.3', 'contact', $secret, 1000), 'csrf:malformed');
+});
+
+test('timing uses authenticated token age', function () use ($secret): void {
+    form_session_reset();
+    $value = token('contact', $secret, 60, 1000);
+
+    $checked = csrf($value, 'contact', $secret, 1002);
+    $fast = timing($checked, 3);
+    same(false, $fast[VALID]);
+    code_is($fast, 'timing:too_fast');
+    same(2, $fast[DATA]['age']);
+
+    $ready = timing(csrf($value, 'contact', $secret, 1003), 3);
+    same(true, $ready[VALID]);
+    same(3, $ready[DATA]['minimum']);
+});
+
+test('honeypot requires a present empty string', function (): void {
+    same(true, honeypot(['company' => ''], 'company')[VALID]);
+    code_is(honeypot([], 'company'), 'honeypot:missing');
+    code_is(honeypot(['company' => 'bot'], 'company'), 'honeypot:filled');
+    code_is(honeypot(['company' => []], 'company'), 'honeypot:non_scalar');
+});
+
+test('shape enforces names, scalar strings, UTF-8 and null rejection', function (): void {
+    $valid = ['_form' => 'x', 'company' => '', 'name' => 'Ada', 'message' => 'Hello'];
+    same(true, shape($valid, ['_form', 'company', 'name'], ['message'], REJECT_UNKNOWN)[VALID]);
+
+    code_is(shape(['name' => 'Ada'], ['name', 'message']), 'shape:missing');
+    code_is(shape(['name' => ['Ada']], ['name']), 'shape:non_scalar');
+    code_is(shape(['name' => "Ada\0Lovelace"], ['name']), 'shape:null_byte');
+    code_is(shape(['name' => "\xC3\x28"], ['name']), 'shape:utf8');
+
+    same(true, shape(['name' => 'Ada', 'submit' => 'Send'], ['name'])[VALID]);
+    code_is(shape(['name' => 'Ada', 'submit' => 'Send'], ['name'], [], REJECT_UNKNOWN), 'shape:unknown');
+
+    throws(\InvalidArgumentException::class, fn() => shape([], ['name', 'name']));
+});
+
+test('verify short-circuits and passes the previous result', function (): void {
+    $ran = false;
+    $stopped = verify(
+        fn() => result(false, 'stop'),
+        function () use (&$ran): array {
+            $ran = true;
+            return result(true);
+        }
+    );
+    code_is($stopped, 'stop');
+    same(false, $ran);
+
+    $timed = verify(
+        fn() => result(true, 'ok', ['age' => 1]),
+        fn(array $previous) => timing($previous, 2)
+    );
+    code_is($timed, 'timing:too_fast');
+
+    throws(\UnexpectedValueException::class, fn() => verify(fn() => 'bad'));
+});
+
+test('generic rate limits are keyed, bounded and reset by window', function (): void {
+    $buckets = [];
+
+    $first = rate($buckets, 'contact', 2, 10, 100);
+    same(true, $first[VALID]);
+    same(1, $first[DATA]['remaining']);
+
+    $second = rate($buckets, 'contact', 2, 10, 100);
+    same(true, $second[VALID]);
+    same(0, $second[DATA]['remaining']);
+
+    $blocked = rate($buckets, 'contact', 2, 10, 100);
+    code_is($blocked, 'rate:limited');
+    same(10, $blocked[DATA]['retry_after']);
+    same(2, $buckets['contact']['count']);
+
+    same(true, rate($buckets, 'signup', 1, 10, 100)[VALID]);
+    same(true, rate($buckets, 'contact', 2, 10, 110)[VALID]);
+    same(1, $buckets['contact']['count']);
+
+    same(true, rate($buckets, 'contact', 2, 20, 111)[VALID]);
+    same(20, $buckets['contact']['window']);
+});
+
+test('session rate limits compose by application key', function (): void {
+    form_session_reset();
+
+    same(true, session_rate('contact:minute', 1, 60, 100)[VALID]);
+    code_is(session_rate('contact:minute', 1, 60, 100), 'rate:limited');
+    same(true, session_rate('contact:hour', 2, 3600, 100)[VALID]);
+});
+
+test('unknown field names are not copied into structured results', function (): void {
+    $unknown = str_repeat('x', 300);
+    $checked = shape(['name' => 'Ada', $unknown => 'value'], ['name'], [], REJECT_UNKNOWN);
+    code_is($checked, 'shape:unknown');
+    same([], $checked[DATA]);
+});
+
+test('form token and session limits require an active session', function () use ($secret): void {
+    session_write_close();
+    try {
+        throws(\LogicException::class, fn() => token('contact', $secret, 60, 100));
+        throws(\LogicException::class, fn() => csrf('bad', 'contact', $secret, 100));
+        throws(\LogicException::class, fn() => session_rate('contact', 1, 60, 100));
+    } finally {
+        session_start();
+    }
+});
+
+test('configuration errors throw rather than becoming verification failures', function () use ($secret): void {
+    throws(\InvalidArgumentException::class, fn() => token('', $secret, 60, 100));
+    throws(\InvalidArgumentException::class, fn() => token('contact', 'short', 60, 100));
+    throws(\InvalidArgumentException::class, fn() => token('contact', $secret, 0, 100));
+    throws(\InvalidArgumentException::class, fn() => token('contact', $secret, TTL_MAX + 1, 100));
+    throws(\InvalidArgumentException::class, function (): void {
+        $buckets = [];
+        rate($buckets, '', 1, 60, 100);
+    });
+});
+
+$failures = [];
+foreach ($tests as [$name, $run]) {
+    try {
+        $run();
+    } catch (\Throwable $fault) {
+        $failures[] = [$name, $fault];
+    }
+}
+
+\session_destroy();
+
+if ($failures) {
+    foreach ($failures as [$name, $fault])
+        \fwrite(STDERR, "FAIL $name\n  {$fault->getMessage()}\n");
+    \fwrite(STDERR, \count($failures) . ' of ' . \count($tests) . " tests failed\n");
+    exit(1);
+}
+
+\fwrite(STDOUT, \count($tests) . " form tests passed\n");


### PR DESCRIPTION
## What changed

- add `bad\form` primitives for structured verification results and short-circuit composition
- add HMAC-authenticated CSRF tokens bound to the active session, form purpose, stable site secret, issue time and expiration
- add honeypot and signed minimum-submission-time checks
- add expected-field, scalar-string, UTF-8, null-byte and optional unknown-field enforcement
- add a storage-neutral fixed-window rate primitive plus a session-scoped wrapper for composable form/application keys
- document a complete contact-form flow and the boundary between deployment controls, BADHAT primitives and application validation
- add an executable 13-case test suite and list the module in the README

## Boundary

Anything enforceable before PHP receives or processes the request remains deployment configuration: body/upload/input limits, timeouts, method and HTTPS enforcement, trusted proxies, coarse IP/global flood controls, session-cookie defaults, production error handling and log management.

Request size, rate limiting and upload prohibition intentionally remain layered: deployment rejects coarse traffic early, while the form/application layer enforces field-specific, session/form-specific and request-specific policy.

Single-use token consumption, submitted-identity rate keys and duplicate-content fingerprinting remain deferred/application concerns.

## Validation

- `php -l form.php`
- `php -l test/form.php`
- `php test/form.php` — 13 form tests passed

The tested local `form.php`, `test/form.php` and `doc/form.md` blobs match the branch blobs on GitHub.